### PR TITLE
Update generate_request so it doesn't fail with some serialnumbers

### DIFF
--- a/custom_components/omnik/sensor.py
+++ b/custom_components/omnik/sensor.py
@@ -280,38 +280,18 @@ class OmnikInverter():
     """
     
     """ Convert the serial number into a bytes array. """
-    serial_hex = '{:x}'.format(serial_number)
-    serial_bytes = bytearray.fromhex(serial_hex)
+    double_hex = hex(serial_number)[2:] * 2
+    serial_bytes = bytearray.fromhex(double_hex)
+    serial_bytes.reverse()
     
-    """ Calculate the checksum. """
-    checksum = 0
-    for x in range(0, 4):
-      checksum += serial_bytes[x]
-    checksum *= 2
-    checksum += 115
-    checksum &= 0xff
-    
-    """ Convert the checksum into a byte. """
-    checksum_hex = '{:x}'.format(int(checksum))
-    checksum_bytes = bytearray.fromhex(checksum_hex)
-    
+    cs_count = 115 + sum(serial_bytes)
+    checksum = bytearray.fromhex(hex(cs_count)[-2:])
+
     """ Construct the message which requests the statistics. """
-    request_data = bytearray()
-    request_data.append(0x68)
-    request_data.append(0x02)
-    request_data.append(0x40)
-    request_data.append(0x30)
-    request_data.append(serial_bytes[3])
-    request_data.append(serial_bytes[2])
-    request_data.append(serial_bytes[1])
-    request_data.append(serial_bytes[0])
-    request_data.append(serial_bytes[3])
-    request_data.append(serial_bytes[2])
-    request_data.append(serial_bytes[1])
-    request_data.append(serial_bytes[0])
-    request_data.append(0x01)
-    request_data.append(0x00)
-    request_data.append(checksum_bytes[0])
+    request_data = bytearray([0x68, 0x02, 0x40, 0x30])
+    request_data.extend(serial_bytes)
+    request_data.extend([0x01, 0x00])
+    request_data.extend(checksum)
     request_data.append(0x16)
     
     return request_data


### PR DESCRIPTION
I couldn't get this sensor to work, I kept receiving this error:
```
Traceback (most recent call last):
  File "test_2.py", line 50, in <module>
    print(generate_request(<my_serial_number>))
  File "test_2.py", line 28, in generate_request
    checksum_bytes = bytearray.fromhex(checksum_hex)
ValueError: non-hexadecimal number found in fromhex() arg at position 1
```

I believe depending on the serialnumber your code might or might not work, for me it didn't 😞 

With some help from other libraries  
- https://github.com/Woutrrr/Omnik-Data-Logger (Python 2) 
- https://github.com/micromys/Omnik (php)

I updated the generate_request method to also work with my serial number.

It's a bit more concise then your version and more similar to other libraries around.